### PR TITLE
basic puffin profiler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ env_logger = "0.9"
 half = "2"
 log = "0.4"
 pollster = "0.2"
+puffin = "0.14"
+puffin_http = "0.11"
 
 # assets
 gltf = "1"

--- a/src/game.rs
+++ b/src/game.rs
@@ -912,6 +912,8 @@ pub fn update_game_state(
     renderer_state: &RendererState,
     logger: &mut Logger,
 ) {
+    puffin::profile_function!();
+
     let time_tracker = game_state.time();
     let global_time_seconds = time_tracker.global_time_seconds();
 

--- a/src/gameloop.rs
+++ b/src/gameloop.rs
@@ -22,6 +22,8 @@ pub fn run(
         *control_flow = ControlFlow::Poll;
         match event {
             Event::RedrawRequested(_) => {
+                puffin::GlobalProfiler::lock().new_frame();
+
                 game_state.on_frame_started();
                 logger.on_frame_completed();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,14 @@ use cgmath::prelude::*;
 
 async fn start() {
     let event_loop = winit::event_loop::EventLoop::new();
+
+    let _puffin_server = {
+        let server_addr = format!("127.0.0.1:{}", puffin_http::DEFAULT_PORT);
+        eprintln!("Serving demo profile data on {}", server_addr);
+        puffin_http::Server::new(&server_addr).unwrap()
+    };
+    puffin::set_scopes_on(true);
+
     let window = {
         let window = winit::window::WindowBuilder::new()
             // .with_inner_size(winit::dpi::LogicalSize::new(1000.0f32, 1000.0f32))

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -2216,6 +2216,8 @@ impl RendererState {
     }
 
     pub fn update(&mut self, game_state: &mut GameState, logger: &mut Logger) {
+        puffin::profile_function!();
+
         // send data to gpu
         let scene = &mut game_state.scene;
         let limits = &mut self.base.limits;
@@ -2520,6 +2522,8 @@ impl RendererState {
     }
 
     pub fn render(&mut self, game_state: &GameState) -> Result<(), wgpu::SurfaceError> {
+        puffin::profile_function!();
+
         let surface_texture = self.base.surface.get_current_texture()?;
         let surface_texture_view = surface_texture
             .texture


### PR DESCRIPTION
This is a basic implementation of the puffin profiler.

It's pretty nice, but it's not a profiler that can generate a complete flamegraph (unless you disseminate the puffin::profile_function!() macro everywhere) but useful nonetheless.

I preferred to implement it with http protocol to avoid having to integrate egui (so we will be free to choose the GUI we would like).

To connect to the profiler during the game use this:
https://github.com/EmbarkStudios/puffin/tree/main/puffin_viewer

To enable/disable the profiler the line to be modified is this: puffin::set_scopes_on(true).

There is also this macro that identifies where the frame ends (I hope I put it in the correct place): puffin::GlobalProfiler::lock().new_frame();